### PR TITLE
fix turnOffLocalCamera in Chrome and Safari

### DIFF
--- a/src/main/webapp/js/webrtc_adaptor.js
+++ b/src/main/webapp/js/webrtc_adaptor.js
@@ -767,7 +767,12 @@ function WebRTCAdaptor(initialValues)
 		if (thiz.remotePeerConnection != null) {
 
 			var track = thiz.localStream.getVideoTracks()[0];
-			track.enabled = false;
+			if (adapter.browserDetails.browser == "firefox") {
+				track.enabled = false;
+			}
+			else {
+				track.stop();
+			}
 		}
 		else {
 			this.callbackError("NoActiveConnection");


### PR DESCRIPTION
```turnOffLocalCamera``` does not work in Chrome and Safari.  This change fixes that issue.

Inspired by https://github.com/twilio/video-quickstart-js/issues/48#issuecomment-398861227