### PR TITLE
Devices are taken only in publish mode

### DIFF
--- a/src/main/webapp/js/webrtc_adaptor.js
+++ b/src/main/webapp/js/webrtc_adaptor.js
@@ -92,16 +92,16 @@ export class WebRTCAdaptor
 			this.callbackError("UnsecureContext");
 			return;
 		}		
-		/*
-		* Check browser support for screen share feature.
-		*/
-		this.checkBrowserScreenShareSupported();
-
-		this.getDevices();
-		this.trackDeviceChange();
 
 		if (!this.isPlayMode && typeof this.mediaConstraints != "undefined" && this.localStream == null)
 		{
+			//Check browser support for screen share function
+			this.checkBrowserScreenShareSupported();
+
+			// Get devices only in publish mode.
+			this.getDevices();
+			this.trackDeviceChange();
+
 			if (typeof this.mediaConstraints.video != "undefined" && this.mediaConstraints.video != false)
 			{
 				this.openStream(this.mediaConstraints, this.mode);	


### PR DESCRIPTION
If webrtc_adaptor called in play mode, constructor should not call getDevices and checkScreenShareSupport.