### PR TITLE
fixes already_playing alert when added via rest and mild readability optimizations

### DIFF
--- a/src/main/webapp/conference.html
+++ b/src/main/webapp/conference.html
@@ -382,6 +382,7 @@ body {
 			video.srcObject = null;
 			document.getElementById("players").removeChild(player);
 		}
+		webRTCAdaptor.stop(streamId);
 	}
 
 	function startAnimation() {
@@ -544,49 +545,27 @@ body {
 					} 
 					else if (info == "play_finished") {
 						console.log("play_finished");
-						var video = document.getElementById("remoteVideo"
-								+ obj.streamId);
-						if (video != null) {
-							video.srcObject = null;
-						}
+						removeRemoteVideo(obj.streamId);
 					} 
 					else if (info == "streamInformation") {
 						streamInformation(obj);
 					} 
 					else if (info == "roomInformation") {
-						var tempRoomStreamList = Array();
-						// Check stream is in room
-						// PS: Old room list mean streams doesn't have own stream ID
-						if (streamsList != null) {
-							for (var i = 0; i < streamsList.length; i++) {
-								var oldStreamListItem = streamsList[i];
-
-								var oldRoomItemIndex = streamsList.indexOf(oldStreamListItem);
-								var newRoomItemIndex = obj.streams.indexOf(oldStreamListItem);
-
-								// If streams item is in obj.streams, it's 
-								if(obj.streams.includes(oldStreamListItem)){
-									if (newRoomItemIndex > -1) {
-  										obj.streams.splice(newRoomItemIndex, 1);
-									}
-									tempRoomStreamList.push(oldStreamListItem);
-								}
-								else{
-									removeRemoteVideo(oldStreamListItem);
-								}
+						//Checks if any new stream has added, if yes, plays.
+						for(let str of obj.streams){
+							if(!streamsList.includes(str)){
+								webRTCAdaptor.play(str, token,
+										roomNameBox.value);
 							}
 						}
-
-						//Play new streams in list
-						if (obj.streams != null) {
-							obj.streams.forEach(function(item) {
-								tempRoomStreamList.push(item);
-								console.log("Stream joined with ID: "+item);
-								webRTCAdaptor.play(item, token,
-										roomNameBox.value);
-							});
+						// Checks if any stream has been removed, if yes, removes the view and stops webrtc connection.
+						for(let str of streamsList){
+							if(!obj.streams.includes(str)){
+								removeRemoteVideo(str);
+							}
 						}
-						streamsList = tempRoomStreamList;
+						//Lastly updates the current streamlist with the fetched one.
+						streamsList=obj.streams;
 					}
 					else if (info == "data_channel_opened") {
 						console.log("Data Channel open for stream id", obj );


### PR DESCRIPTION
fixes https://github.com/ant-media/Ant-Media-Server/issues/2799
Now when adding and removing same streamid to the room, no issues are happening and outcome is expected.
Also:
Simplified roominformation callback. It is more readable, at least for me. Removed duplicated code at play_finished callback, now using removeremotevideo to handle same thing.
