### PR TITLE
Maintain mediaConstraints on change of input

### DIFF
--- a/src/main/webapp/js/webrtc_adaptor.js
+++ b/src/main/webapp/js/webrtc_adaptor.js
@@ -748,7 +748,10 @@ export class WebRTCAdaptor
 		}
 
 		if (typeof deviceId != "undefined" ) {
-			this.mediaConstraints.audio = { "deviceId": deviceId };
+			if(this.mediaConstraints.audio !== true)
+				this.mediaConstraints.audio.deviceId = deviceId;
+			else 
+				this.mediaConstraints.audio = { "deviceId": deviceId };
 		}
 		this.setAudioInputSource(streamId, this.mediaConstraints, null, true, deviceId);
 	}
@@ -767,7 +770,10 @@ export class WebRTCAdaptor
 		this.publishMode = "camera";
 
 		if (typeof deviceId != "undefined" ) {
-			this.mediaConstraints.video = { "deviceId": deviceId };
+			if(this.mediaConstraints.video !== true)
+				this.mediaConstraints.video.deviceId = deviceId;
+			else 
+				this.mediaConstraints.video = { "deviceId": deviceId };
 		}
 		this.setVideoCameraSource(streamId, this.mediaConstraints, null, true, deviceId);
 	}


### PR DESCRIPTION
This checks to see if media constraints have been defined beyond "true" and changes the device based on that state.

Currently, if the mediaConstraints are set to anything but {audio: true, video: true}, and then the input is changed with that method, the mediaConstraints are no longer used after the device is changed.