### PR TITLE
play finished fix

### DIFF
--- a/src/main/webapp/conference.html
+++ b/src/main/webapp/conference.html
@@ -381,6 +381,7 @@ body {
 			document.getElementById("players").removeChild(player);
 		}
 		webRTCAdaptor.stop(streamId);
+		streamsList = streamsList.filter(item => item !== streamId);
 	}
 
 	function startAnimation() {


### PR DESCRIPTION
https://github.com/ant-media/Ant-Media-Server/issues/3060
In weak network conditions, play finished may happen and when this happens, it doesn't mean that stream is not publishing anymore. It still might be in the room. If it does, it won't play it since it is already available in the streamsList. So, in this case, when play_finished received, we are removing that streamId from the streamsList. So, if that stream is still publishing, it will be in the roominformation which will be played right away. In previous version, when we got play_finished, we were stopping the stream and removing the video but if stream is still in the streamsList and incoming roominformation includes that streamId, it wouldn't be played since it is already in our list.
This fixes the aforementioned issue.