### PR TITLE
Remove deprecated addStream function.

### DIFF
--- a/src/main/webapp/js/webrtc_adaptor.js
+++ b/src/main/webapp/js/webrtc_adaptor.js
@@ -671,7 +671,11 @@ export class WebRTCAdaptor
 			if (!this.playStreamId.includes(streamId))
 			{
 				if(this.mediaManager.localStream != null) {
-					this.remotePeerConnection[streamId].addStream(this.mediaManager.localStream);
+					let pc = this.remotePeerConnection[streamId];
+					let stream = this.mediaManager.localStream;
+					stream.getTracks().forEach(function (track) {
+					  pc.addTrack(track, stream);
+					});
 				}
 			}
 			this.remotePeerConnection[streamId].onicecandidate = event => {


### PR DESCRIPTION
Migrate initPeerConnection to use addTrack() instead of deprecated addStream() in order to support safari.

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/addStream