### PR TITLE
Added new constructor parameters to pass video element instead of video element id

### DIFF
--- a/src/main/webapp/js/media_manager.js
+++ b/src/main/webapp/js/media_manager.js
@@ -155,7 +155,7 @@ export class MediaManager
 		/**
 		 * html video element that presents local stream
 		 */
-		 this.localVideo = document.getElementById(this.localVideoId);
+		 this.localVideo = this.localVideoElement || document.getElementById(this.localVideoId);
 
 		 //A dummy stream created to replace the tracks when camera is turned off.
 		 this.dummyCanvas = document.createElement("canvas");

--- a/src/main/webapp/js/webrtc_adaptor.js
+++ b/src/main/webapp/js/webrtc_adaptor.js
@@ -180,7 +180,7 @@ export class WebRTCAdaptor
 		/**
 		 * The html video tag for receiver is got here
 		 */
-		this.remoteVideo = document.getElementById(this.remoteVideoId);
+		this.remoteVideo = this.remoteVideoElement || document.getElementById(this.remoteVideoId);
 
 		/**
 		  * Keeps the sound meters for each connection. Its index is stream id


### PR DESCRIPTION
In Vue app context document.getElementById('anything') returns null and beacuse of that `WebsocketAdaptor` becomes unusable.
This PR fixes this by allowing to pass  `localVideoElement` and `remoteVideoElement` parameters to `WebsocketAdaptor` constructor.