### PR TITLE
Added MediaManager method to change local video property programmatically

### DIFF
--- a/src/main/webapp/js/media_manager.js
+++ b/src/main/webapp/js/media_manager.js
@@ -635,6 +635,18 @@ export class MediaManager
 			resolve();
 		})
 	}
+
+	/**
+	 * Changes local video and sets localStream as source
+	 *
+	 * @param {*} videoEl
+	 */
+	changeLocalVideo(videoEl) {
+		this.localVideo = videoEl
+		if (this.localStream) {
+			this.localVideo.srcObject = this.localStream
+		}
+	}
 	
 	/**
 	 * These methods are initialized when the user is muted himself in a publish scenario


### PR DESCRIPTION
Hi!
I've added this method to allow `WebRTCAdaptor` consumers to set `localVideo` whenever they wish.
Cheers! 😉